### PR TITLE
Fixed impressions and clicks not showing for anonymous users

### DIFF
--- a/ads/__init__.py
+++ b/ads/__init__.py
@@ -1,3 +1,3 @@
 default_app_config = 'ads.apps.AdsConfig'
 
-__version__ = '1.2.0'
+__version__ = '1.2.1'

--- a/ads/utils.py
+++ b/ads/utils.py
@@ -7,15 +7,15 @@ from ads.models import Click, Impression
 
 def get_zones_choices():
     for key in sorted(settings.ADS_ZONES):
-        yield (key, _(settings.ADS_ZONES[key].get('name', 'Undefined')))
+        yield (key, _(settings.ADS_ZONES[key].get("name", "Undefined")))
 
 
 def get_client_ip(request):
-    x_forwarded_for = request.META.get('HTTP_X_FORWARDED_FOR', None)
+    x_forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR", None)
     if x_forwarded_for:
-        ip = x_forwarded_for.split(',')[0]
+        ip = x_forwarded_for.split(",")[0]
     else:
-        ip = request.META.get('REMOTE_ADDR', '')
+        ip = request.META.get("REMOTE_ADDR", "")
     return ip
 
 
@@ -26,18 +26,22 @@ def update_clicks(ad, request):
                 ad=ad,
                 session_id=request.session.session_key,
                 defaults={
-                    'click_date': timezone.now(),
-                    'source_ip': get_client_ip(request),
-                })
+                    "click_date": timezone.now(),
+                    "source_ip": get_client_ip(request),
+                },
+            )
 
 
 def update_impressions(ad, request):
     if ad is not None:
-        if request.session.session_key:
-            impression, created = Impression.objects.get_or_create(
-                ad=ad,
-                session_id=request.session.session_key,
-                defaults={
-                    'impression_date': timezone.now(),
-                    'source_ip': get_client_ip(request),
-                })
+        # if request.session.session_key:
+        request.session["django-ads"] = True
+        request.session.save()
+        impression, created = Impression.objects.get_or_create(
+            ad=ad,
+            session_id=request.session.session_key,
+            defaults={
+                "impression_date": timezone.now(),
+                "source_ip": get_client_ip(request),
+            },
+        )


### PR DESCRIPTION
Record session data for anonymous users as mentioned [here](https://github.com/razisayyed/django-ads/issues/8#issue-261188583).